### PR TITLE
Add `lift()` modifier to support binary+ functions with placeholders

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -2,6 +2,8 @@ module.exports = {
   presets: [['@babel/env', {
     targets: { node: 6 },
     loose: true
-  }], '@babel/stage-1'],
+  }], ['@babel/stage-1', {
+    decoratorsLegacy: true
+  }]],
   plugins: ['babel-plugin-macros']
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,10 +1,15 @@
 "use strict";
 
+exports.__esModule = true;
+exports.default = void 0;
+
 var _babelPluginMacros = require("babel-plugin-macros");
 
 var _placeholders = _interopRequireDefault(require("./placeholders"));
 
 var _implicitParams = _interopRequireDefault(require("./implicit-params"));
+
+var _lift = _interopRequireDefault(require("./lift"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -19,6 +24,9 @@ function transform({
   if (references.it) (0, _implicitParams.default)(t, references.it);
   if (references.default) (0, _implicitParams.default)(t, references.default);
   if (references._) (0, _placeholders.default)(t, references._);
+  if (references.lift) (0, _lift.default)(t, references.lift);
 }
 
-module.exports = (0, _babelPluginMacros.createMacro)(transform);
+var _default = (0, _babelPluginMacros.createMacro)(transform);
+
+exports.default = _default;

--- a/dist/lift.js
+++ b/dist/lift.js
@@ -1,0 +1,24 @@
+"use strict";
+
+exports.__esModule = true;
+exports.default = transformLift;
+
+var _util = require("./util");
+
+function transformLift(t, refs) {
+  refs.forEach(referencePath => {
+    const parentPath = referencePath.parentPath;
+
+    if (!parentPath.isCallExpression()) {
+      throw new _util.PartialError('`lift` can only be used as a call expression');
+    }
+
+    const args = parentPath.get('arguments');
+
+    if (args.length !== 1) {
+      throw new _util.PartialError('`lift` accepts a single expression as its only argument');
+    }
+
+    parentPath.replaceWith(args[0]);
+  });
+}

--- a/dist/util.js
+++ b/dist/util.js
@@ -14,7 +14,8 @@ exports.shouldHoist = shouldHoist;
 exports.wasMacro = wasMacro;
 exports.PartialError = void 0;
 const nonHoistTypes = ['Identifier', 'ArrayExpression', 'ObjectExpression', 'FunctionExpression', 'ArrowFunctionExpression'];
-let PartialError = class PartialError extends Error {
+
+class PartialError extends Error {
   constructor(message) {
     super(message);
     this.name = 'PartialError';
@@ -26,7 +27,8 @@ let PartialError = class PartialError extends Error {
     }
   }
 
-};
+}
+
 exports.PartialError = PartialError;
 
 function isPipeline(path, child) {

--- a/package.json
+++ b/package.json
@@ -42,15 +42,15 @@
     "prepublishOnly": "npm test"
   },
   "dependencies": {
-    "babel-plugin-macros": "^2.0.0"
+    "babel-plugin-macros": "^2.2.2"
   },
   "devDependencies": {
-    "@babel/cli": "7.0.0-beta.36",
-    "@babel/core": "7.0.0-beta.36",
-    "@babel/preset-env": "7.0.0-beta.36",
-    "@babel/preset-stage-1": "7.0.0-beta.36",
-    "ava": "^0.24.0",
-    "babel-core": "^6.26.0",
+    "@babel/cli": "7.0.0-beta.51",
+    "@babel/core": "7.0.0-beta.51",
+    "@babel/preset-env": "7.0.0-beta.51",
+    "@babel/preset-stage-1": "7.0.0-beta.51",
+    "ava": "1.0.0-beta.6",
+    "babel-core": "^6.26.3",
     "dedent": "^0.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "param.macro",
-  "version": "2.0.0",
+  "version": "2.1.0-beta.1",
   "description": "Partial application syntax and lambda parameters for JavaScript, inspired by Scala's `_` & Kotlin's `it`",
   "author": {
     "name": "Bo Lingen",

--- a/plugin.js
+++ b/plugin.js
@@ -2,6 +2,7 @@
 
 const transformImplicitParams = require('./dist/implicit-params').default
 const transformPlaceholders = require('./dist/placeholders').default
+const transformLift = require('./dist/lift').default
 const { name } = require('./package.json')
 
 const isPrimitive = val =>
@@ -62,6 +63,7 @@ const applyPlugin = (babel, path, imports) => {
   if (references.it) transformImplicitParams(babel.types, references.it)
   if (references.default) transformImplicitParams(babel.types, references.default)
   if (references._) transformPlaceholders(babel.types, references._)
+  if (references.lift) transformLift(babel.types, references.lift)
 }
 
 module.exports = babel => {

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { createMacro } from 'babel-plugin-macros'
 
 import transformPlaceholders from './placeholders'
 import transformImplicitParams from './implicit-params'
+import transformLift from './lift'
 
 function transform ({ references, state, babel: { types: t } }) {
   // `it` needs to be transformed before `_` to allow them to work together
@@ -9,6 +10,7 @@ function transform ({ references, state, babel: { types: t } }) {
   if (references.it) transformImplicitParams(t, references.it)
   if (references.default) transformImplicitParams(t, references.default)
   if (references._) transformPlaceholders(t, references._)
+  if (references.lift) transformLift(t, references.lift)
 }
 
 export default createMacro(transform)

--- a/src/index.js
+++ b/src/index.js
@@ -11,4 +11,4 @@ function transform ({ references, state, babel: { types: t } }) {
   if (references._) transformPlaceholders(t, references._)
 }
 
-module.exports = createMacro(transform)
+export default createMacro(transform)

--- a/src/lift.js
+++ b/src/lift.js
@@ -1,0 +1,19 @@
+import { PartialError } from './util'
+
+export default function transformLift (t, refs) {
+  refs.forEach(referencePath => {
+    const { parentPath } = referencePath
+
+    if (!parentPath.isCallExpression()) {
+      throw new PartialError('`lift` can only be used as a call expression')
+    }
+
+    const args = parentPath.get('arguments')
+
+    if (args.length !== 1) {
+      throw new PartialError('`lift` accepts a single expression as its only argument')
+    }
+
+    parentPath.replaceWith(args[0])
+  })
+}


### PR DESCRIPTION
Closes #9 

Users may want to use `_` placeholders rather than extracting some contrived inline function. This PR adds a new token called `lift` that makes this possible. It acts as a function accepting only a single expression and is essentially removed completely from the output.

This maintains the simplicity of the existing 2 tokens and can serve as a middle ground between `_` and `it`.

**input:**

```js
import { _, lift } from 'param.macro'

;[1, 2, 3, 4].reduce(lift(_ + _))
```

**output:**

```js
[1, 2, 3, 4].reduce((_arg, _arg2) => {
  return _arg + _arg2;
});
```

---

Non-placeholder arguments essentially just replace the `lift` call:

**input:**

```js
import { it, lift } from 'param.macro'

;[1, 2, 3, 4].reduce(lift(it + it))

console.log(lift(1 + 1))
```

**output:**

```js
[1, 2, 3, 4].reduce(_it => {
  return _it + _it;
});

console.log(1 + 1);
```

---

This is available in `2.1.0-beta.1` which you can install by version or using the `@next` tag:

```console
# yarn:
yarn add -D param.macro@2.1.0-beta.1
yarn add -D param.macro@next

# npm:
npm i -D param.macro@2.1.0-beta.1
npm i -D param.macro@next
```