### PR TITLE
docs(readme): explain how `it` and `_` can differ for method calls by scope

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -358,7 +358,11 @@ const map1 = _.map(_)
 const map2 = it.map(_)
 ```
 
-_However_, if nested deeper inside a function call, the object placeholder `_` would traverse upward and create a separate function _first_, before being passed the `_` inside the method call itself. This creates a unary method call instead of the implicit binary function we wanted, lift or not.
+_However_, if nested deeper inside a function call the object placeholder `_` in
+`map1` above would traverse further upward than an `it` would, and create a separate
+function _first_, before the argument placeholder `_` inside the method call itself.
+This creates an unary method call instead of the implicit binary function we probably
+wanted, `lift` or not.
 
 The `it` implementation _does_ still create the implicit binary function, even if nested deeper. And following their own rules any `_` inside the method call will traverse up to the method call and stop to create a function there, as we wanted.
 

--- a/readme.md
+++ b/readme.md
@@ -345,7 +345,9 @@ _arg => array.map(_arg)
 array.map(_it => _it)
 ```
 
-Likewise, only at the top-level and as the right-hand side of an assignment does `it` and `_` behave similarly when used to produce implicit n-ary functions — since there's no further upward to go they can both stop at the same place.
+An exception to these scoping differences is at the top-level, like the right-hand
+side of an assignment. `it` and `_` behave similarly here since there's no further
+upward to go, so they'll both happen to target the same place.
 
 The following two map implementations do the same thing:
 

--- a/readme.md
+++ b/readme.md
@@ -364,7 +364,10 @@ function _first_, before the argument placeholder `_` inside the method call its
 This creates an unary method call instead of the implicit binary function we probably
 wanted, `lift` or not.
 
-The `it` implementation _does_ still create the implicit binary function, even if nested deeper. And following their own rules any `_` inside the method call will traverse up to the method call and stop to create a function there, as we wanted.
+The `it` implementation in `map2` above _does_ still create the implicit binary
+function, even if nested deeper. And following the normal placeholder rules, any `_`
+inside the method call will traverse up to the method call and stop to create a
+function there, as we wanted.
 
 ### argument reuse
 

--- a/readme.md
+++ b/readme.md
@@ -349,7 +349,7 @@ An exception to these scoping differences is at the top-level, like the right-ha
 side of an assignment. `it` and `_` behave similarly here since there's no further
 upward to go, so they'll both happen to target the same place.
 
-The following two map implementations do the same thing:
+For example the following two map implementations do the same thing:
 
 ```js
 import { _, it } from 'param.macro'

--- a/readme.md
+++ b/readme.md
@@ -174,7 +174,7 @@ object like this:
 ```js
 import { _ } from 'param.macro'
 
-const hasOwn = _.hasOwnProperty(_)
+const hasOwn = it.hasOwnProperty(_)
 const object = { flammable: true }
 
 hasOwn(object, 'flammable')
@@ -344,6 +344,21 @@ const array = [1, 2, 3]
 _arg => array.map(_arg)
 array.map(_it => _it)
 ```
+
+Likewise, only at the top-level and as the right-hand side of an assignment does `it` and `_` behave similarly when used to produce implicit n-ary functions — since there's no further upward to go they can both stop at the same place.
+
+The following two map implementations do the same thing:
+
+```js
+import { _, it } from 'param.macro'
+
+const map1 = _.map(_)
+const map2 = it.map(_)
+```
+
+_However_, if nested deeper inside a function call, the object placeholder `_` would traverse upward and create a separate function _first_, before being passed the `_` inside the method call itself. This creates a unary method call instead of the implicit binary function we wanted, lift or not.
+
+The `it` implementation _does_ still create the implicit binary function, even if nested deeper. And following their own rules any `_` inside the method call will traverse up to the method call and stop to create a function there, as we wanted.
 
 ### argument reuse
 


### PR DESCRIPTION
Fixes citycide/param.macro#15